### PR TITLE
Reorder `defer`'d closers

### DIFF
--- a/pipeline/compress/compress.go
+++ b/pipeline/compress/compress.go
@@ -44,9 +44,9 @@ func create(system, arch string, config config.ProjectConfig) error {
 	gw := gzip.NewWriter(file)
 	tw := tar.NewWriter(gw)
 	defer func() {
-		_ = file.Close()
-		_ = gw.Close()
 		_ = tw.Close()
+		_ = gw.Close()
+		_ = file.Close()
 	}()
 	for _, f := range config.Files {
 		if err := addFile(tw, f, f); err != nil {


### PR DESCRIPTION
Commit https://github.com/goreleaser/releaser/commit/40de5c5c644d69c3d33a6d0cf16e539a0f40423b introduces a regression (see comment) whereby
the tarball is closed before data is completely written, thus breaking the release package.

Verified by building the package, running the package and then:

```bash
$ tar vvxf dist/release_Darwin_x86_64.tar.gz
x LICENSE.md
x README.md
x release
```

This PR is a response to https://github.com/goreleaser/releaser/issues/40