### PR TITLE
improve brew formulae

### DIFF
--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -18,7 +18,7 @@ import (
 const formulae = `class {{ .Name }} < Formula
   desc "{{ .Desc }}"
   homepage "{{ .Homepage }}"
-  url "https://github.com/{{ .Repo }}/releases/download/{{ .Tag }}/{{ .BinaryName }}_#{%x(uname -s).gsub(/\n/, '')}_#{%x(uname -m).gsub(/\n/, '')}.tar.gz"
+  url "https://github.com/{{ .Repo }}/releases/download/{{ .Tag }}/{{ .BinaryName }}_Darwin_x86_64.tar.gz"
   head "https://github.com/{{ .Repo }}.git"
   version "{{ .Tag }}"
 

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -67,7 +67,7 @@ func (Pipe) Run(config config.ProjectConfig) error {
 	if err != nil {
 		return err
 	}
-	sha, err := sha(client, owner, repo, name, out)
+	sha, err := formulaeSHA(client, owner, repo, name, out)
 	if err != nil {
 		return err
 	}
@@ -79,13 +79,13 @@ func (Pipe) Run(config config.ProjectConfig) error {
 			},
 			Content: out.Bytes(),
 			Message: github.String(config.BinaryName + " version " + config.Git.CurrentTag),
-			SHA256:  sha,
+			SHA:     sha,
 		},
 	)
 	return err
 }
 
-func sha(client *github.Client, owner, repo, name string, out bytes.Buffer) (*string, error) {
+func formulaeSHA(client *github.Client, owner, repo, name string, out bytes.Buffer) (*string, error) {
 	file, _, _, err := client.Repositories.GetContents(
 		owner, repo, name, &github.RepositoryContentGetOptions{},
 	)
@@ -144,6 +144,7 @@ func dataFor(config config.ProjectConfig, client *github.Client) (result templat
 		BinaryName: config.BinaryName,
 		Caveats:    config.Brew.Caveats,
 		Format:     config.Archive.Format,
+		SHA256:     sum,
 	}, err
 }
 

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -25,6 +25,7 @@ var defaultTemplateData = templateData{
 	Name:       "Test",
 	Repo:       "caarlos0/test",
 	Tag:        "v0.1.3",
+	SHA256:     "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68",
 	Format:     "tar.gz",
 }
 
@@ -33,9 +34,10 @@ func assertDefaultTemplateData(t *testing.T, formulae string) {
 	assert.Contains(formulae, "class Test < Formula")
 	assert.Contains(formulae, "homepage \"https://google.com\"")
 	assert.Contains(formulae, "url \"https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz\"")
-	assert.Contains(formulae, "head \"https://github.com/caarlos0/test.git\"")
+	assert.Contains(formulae, "sha256 \"1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68\"")
 	assert.Contains(formulae, "version \"v0.1.3\"")
 	assert.Contains(formulae, "bin.install \"test\"")
+
 }
 
 func TestFullFormulae(t *testing.T) {

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -31,7 +31,7 @@ func assertDefaultTemplateData(t *testing.T, formulae string) {
 	assert := assert.New(t)
 	assert.Contains(formulae, "class Test < Formula")
 	assert.Contains(formulae, "homepage \"https://google.com\"")
-	assert.Contains(formulae, "url \"https://github.com/caarlos0/test/releases/download/v0.1.3/test_#{%x(uname -s).gsub(/\\n/, '')}_#{%x(uname -m).gsub(/\\n/, '')}.tar.gz\"")
+	assert.Contains(formulae, "url \"https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz\"")
 	assert.Contains(formulae, "head \"https://github.com/caarlos0/test.git\"")
 	assert.Contains(formulae, "version \"v0.1.3\"")
 	assert.Contains(formulae, "bin.install \"test\"")

--- a/sha256sum/sha256.go
+++ b/sha256sum/sha256.go
@@ -12,7 +12,7 @@ func For(path string) (result string, err error) {
 	if err != nil {
 		return
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	hash := sha256.New()
 	_, err = io.Copy(hash, file)

--- a/sha256sum/sha256.go
+++ b/sha256sum/sha256.go
@@ -1,0 +1,25 @@
+package sha256sum
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+)
+
+func For(path string) (result string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return
+	}
+
+	result = hex.EncodeToString(hash.Sum(nil))
+	return
+}


### PR DESCRIPTION
- drop linuxbrew support
- drop i386 macs support
- add sha256 (to avoid warnings)
- remove useless `head` statement

closes #50 